### PR TITLE
Update quiz text to 'green career' and revise final screen

### DIFF
--- a/CAREER_RECOMMENDATION_LOGIC.md
+++ b/CAREER_RECOMMENDATION_LOGIC.md
@@ -1,6 +1,6 @@
 # Career Recommendation Logic
 
-This document explains how the Software Career Quiz determines which careers to recommend to the user based on their answers.
+This document explains how the Green Career Quiz determines which careers to recommend to the user based on their answers.
 
 The core logic resides in the `src/quizRunner.js` file, specifically within the `displayResults` function and its helpers. Here's a step-by-step breakdown:
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <title>Software Career Quiz</title>
+    <title>Green Career Quiz</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap-theme.min.css">
     <link rel="stylesheet" href="styles/application.css">
@@ -14,7 +14,7 @@
       <div class="row">
         <h1 id="quiz-header" class="col-lg-8 col-md-8 col-sm-12 col-xs-12">
           <img src="img/GetZero_logo_small_300px.png" alt="GetZero Logo" id="company-logo">
-          <span class= "black">SOFTWARE CAREER</span>
+          <span class= "black">GREEN CAREER</span>
           <span class="red">QUIZ</span>
         </h1>
 
@@ -42,11 +42,11 @@
           <ol id="results-section"></ol>
         </div>
         <div class="button-container col-lg-8 col-md-8 col-sm-12 col-xs-12">
-          <p class="cta-body-text built-with-container">Get an action packed Ebook to prepare for a great software career.
+          <p class="cta-body-text built-with-container">If you want to explore more green careers and a get personalised green career plan, please click on the link to sign up for GetZero's Green Skills Coach - a completely free chatbot service to help people find their path to a greener career!
           </p>
           <div>
-            <a title="Get your Ebook!" href="https://drive.google.com/file/d/0B75WkMfHj9ndYkFsbWFRTzVhcDg/view?usp=sharing" class="btn btn-red btn-results">
-            Get your Ebook!</a>
+            <a title="Sign up now" href="https://forms.gle/RkFM3UBDjKQJf6Kv9" class="btn btn-red btn-results">
+            sign up now</a>
           </div>
           <p class="cta-body-text built-with-container">
             Built with <span class='cta-red'>&hearts;</span> by <a href='http://www.multunus.com/' class='multunus-link' title='Multunus Software' alt='Multunus Software'>Multunus</a>.
@@ -77,7 +77,7 @@
             <p class="cta-body-text">Please share the quiz and the ebook with them.</p>
             <div class="fb-share-section col-lg-12 col-md-12 col-sm-12 col-xs-12">
               <div class="col-md-4 col-sm-8 col-xs-12">
-                <a href="https://www.facebook.com/sharer/sharer.php?u=http://www.dudeonbench.com/careerquiz/" title='5 Minute Software Career Quiz' alt='5 Minute Software Career Quiz'>
+                <a href="https://www.facebook.com/sharer/sharer.php?u=http://www.dudeonbench.com/careerquiz/" title='5 Minute Green Career Quiz' alt='5 Minute Green Career Quiz'>
                   <button id="fb-share" class="nav-facebook">
                     <div class="social-text">
                       <span class="facebook-icon social-icon">


### PR DESCRIPTION
This commit addresses the issue by:
- Replacing all instances of "software career" with "green career" in user-facing text.
- Updating the title of the quiz to "Green Career Quiz".
- Modifying the final results screen text to direct users to GetZero's Green Skills Coach.
- Changing the call-to-action button on the final screen to "sign up now" and linking it to the specified Google Form.
- Updating the Facebook share title to reflect "Green Career Quiz".
- Amending the `CAREER_RECOMMENDATION_LOGIC.md` to refer to the "Green Career Quiz".